### PR TITLE
fix(external_api): Fix screensharing for Firefox 74

### DIFF
--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -300,7 +300,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
-        this._frame.allow = 'camera; microphone';
+        this._frame.allow = 'camera; microphone; display-capture';
         this._frame.src = this._url;
         this._frame.name = frameName;
         this._frame.id = frameName;


### PR DESCRIPTION
Starting from version 74, firefox need to be explicitly allowed to capture the screen from an iframe for screensharing. This new Feature-Policy is called "display-capture".
See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/display-capture